### PR TITLE
Fix hotkey disabling using Hammerspoon API

### DIFF
--- a/hammerspoon.lua
+++ b/hammerspoon.lua
@@ -12,15 +12,11 @@ local function remapKey(modifiers, key, keyCode)
 end
 
 local function disableAllHotkeys()
-   for k, v in pairs(hs.hotkey.getHotkeys()) do
-      v['_hk']:disable()
-   end
+   hs.hotkey.disableAll()
 end
 
 local function enableAllHotkeys()
-   for k, v in pairs(hs.hotkey.getHotkeys()) do
-      v['_hk']:enable()
-   end
+   hs.hotkey.enableAll()
 end
 
 local function handleGlobalAppEvent(name, event, app)


### PR DESCRIPTION
## Summary
- Replace manual hotkey loop with built-in `hs.hotkey.disableAll`/`enableAll`.

## Testing
- `luac -p hammerspoon.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d4f1ddf84832b81a65d1a34b4df2c